### PR TITLE
feat(SCRUM-19): implementar edición de pensionados asociados a entidades

### DIFF
--- a/src/main/java/com/unicauca/pensionados/back_pensionados/CapaServicio/servicios/IServicioEntidad.java
+++ b/src/main/java/com/unicauca/pensionados/back_pensionados/CapaServicio/servicios/IServicioEntidad.java
@@ -2,6 +2,7 @@ package com.unicauca.pensionados.back_pensionados.CapaServicio.servicios;
 
 import com.unicauca.pensionados.back_pensionados.capaAccesoADatos.modelos.Entidad;
 import com.unicauca.pensionados.back_pensionados.capaPresentacion.dto.peticion.RegistroEntidadPeticion;
+import com.unicauca.pensionados.back_pensionados.capaPresentacion.dto.peticion.RegistroTrabajoPeticion;
 
 import java.util.List;
 
@@ -17,4 +18,5 @@ public interface IServicioEntidad {
     void actualizar(Long nid, RegistroEntidadPeticion entidad);
     boolean activarEntidad(Long nid);
     boolean desactivarEntidad(Long nid);
+    void editarPensionadosDeEntidad(Long nitEntidad, List<RegistroTrabajoPeticion> trabajosActualizados);
 }

--- a/src/main/java/com/unicauca/pensionados/back_pensionados/capaAccesoADatos/repositories/TrabajoRepositorio.java
+++ b/src/main/java/com/unicauca/pensionados/back_pensionados/capaAccesoADatos/repositories/TrabajoRepositorio.java
@@ -1,10 +1,11 @@
 package com.unicauca.pensionados.back_pensionados.capaAccesoADatos.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 import com.unicauca.pensionados.back_pensionados.capaAccesoADatos.modelos.Trabajo;
 import com.unicauca.pensionados.back_pensionados.capaAccesoADatos.modelos.Trabajo.TrabajoId;
 
 public interface TrabajoRepositorio extends JpaRepository<Trabajo, TrabajoId> {
-
+    List<Trabajo> findByEntidadNitEntidad(Long nitEntidad);
 }

--- a/src/main/java/com/unicauca/pensionados/back_pensionados/capaPresentacion/controladores/ControladorEntidad.java
+++ b/src/main/java/com/unicauca/pensionados/back_pensionados/capaPresentacion/controladores/ControladorEntidad.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import com.unicauca.pensionados.back_pensionados.capaPresentacion.dto.peticion.RegistroEntidadPeticion;
 import com.unicauca.pensionados.back_pensionados.CapaServicio.servicios.IServicioEntidad;
 import com.unicauca.pensionados.back_pensionados.capaAccesoADatos.modelos.Entidad;
+import com.unicauca.pensionados.back_pensionados.capaPresentacion.dto.peticion.RegistroTrabajoPeticion;
 
 import java.util.List;
 
@@ -110,6 +111,18 @@ public class ControladorEntidad {
         } catch (Exception ex) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body("Error al desactivar la entidad: " + ex.getMessage());
+        }
+    }
+
+    @PutMapping("/editarPensionados/{nitEntidad}")
+    public ResponseEntity<?> editarPensionadosDeEntidad(@PathVariable Long nitEntidad, @RequestBody List<RegistroTrabajoPeticion> trabajosActualizados) {
+        try {
+            entidadService.editarPensionadosDeEntidad(nitEntidad, trabajosActualizados);
+            return ResponseEntity.ok("Pensionados de la entidad actualizados exitosamente");
+        } catch (RuntimeException ex) {
+            return ResponseEntity.badRequest().body("Error al actualizar pensionados: " + ex.getMessage());
+        } catch (Exception ex) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error interno del servidor: " + ex.getMessage());
         }
     }
 }


### PR DESCRIPTION
- Se desarrolló la función `editarPensionadosDeEntidad` en el servicio.
- Se añadió el endpoint `/api/entidades/editar-pensionados/{nitEntidad}`.
- Se habilitaron operaciones para agregar, eliminar y actualizar días de servicio de pensionados